### PR TITLE
Set feature conformance warnings on ZAP file import and Replace outdated equivalents

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3651,7 +3651,7 @@ This module provides queries for features.
     * [~checkMissingTerms(expression, elementMap)](#module_DB API_ feature related queries..checkMissingTerms) ⇒
     * [~filterElementsContainingDesc(elements)](#module_DB API_ feature related queries..filterElementsContainingDesc) ⇒
     * [~filterRelatedDescElements(elements, featureCode)](#module_DB API_ feature related queries..filterRelatedDescElements) ⇒
-    * [~generateWarningMessage(featureData, endpointId, missingTerms, featureMap, descElements)](#module_DB API_ feature related queries..generateWarningMessage) ⇒
+    * [~generateWarningMessage(featureData, endpointId, elementMap, featureMap, descElements)](#module_DB API_ feature related queries..generateWarningMessage) ⇒
     * [~checkElementConformance(elements, featureMap, featureData, endpointId)](#module_DB API_ feature related queries..checkElementConformance) ⇒
     * [~filterElementsToUpdate(elements, elementMap, featureCode)](#module_DB API_ feature related queries..filterElementsToUpdate) ⇒
     * [~getOutdatedElementWarning(featureData, elements, elementMap)](#module_DB API_ feature related queries..getOutdatedElementWarning) ⇒
@@ -3762,9 +3762,9 @@ Filter an array of elements by if any element has conformance containing the ter
 
 <a name="module_DB API_ feature related queries..generateWarningMessage"></a>
 
-### DB API: feature related queries~generateWarningMessage(featureData, endpointId, missingTerms, featureMap, descElements) ⇒
+### DB API: feature related queries~generateWarningMessage(featureData, endpointId, elementMap, featureMap, descElements) ⇒
 Generate a warning message after processing conformance of the updated device type feature.
-Set flags to decide whether to show a popup warning or disable changes in the frontend.
+Set flags to decide whether to show warnings or disable changes in the frontend.
 
 **Kind**: inner method of [<code>DB API: feature related queries</code>](#module_DB API_ feature related queries)  
 **Returns**: warning message array, disableChange flag, and displayWarning flag  
@@ -3773,7 +3773,7 @@ Set flags to decide whether to show a popup warning or disable changes in the fr
 | --- | --- |
 | featureData | <code>\*</code> | 
 | endpointId | <code>\*</code> | 
-| missingTerms | <code>\*</code> | 
+| elementMap | <code>\*</code> | 
 | featureMap | <code>\*</code> | 
 | descElements | <code>\*</code> | 
 

--- a/src-electron/db/query-feature.js
+++ b/src-electron/db/query-feature.js
@@ -306,12 +306,8 @@ function generateWarningMessage(
   result.warningMessage = []
 
   let warningPrefix =
-    'On endpoint ' +
-    endpointId +
-    ', cluster: ' +
-    featureData.cluster +
-    ', feature: ' +
-    featureName
+    `On endpoint ${endpointId}, cluster: ${featureData.cluster}, ` +
+    `feature: ${featureName} (bit ${featureData.bit} in featureMap attribute)`
 
   let missingTerms = []
   if (Object.keys(elementMap).length > 0) {

--- a/src-electron/db/query-feature.js
+++ b/src-electron/db/query-feature.js
@@ -306,7 +306,7 @@ function generateWarningMessage(
   result.warningMessage = []
 
   let warningPrefix =
-    `On endpoint ${endpointId}, cluster: ${featureData.cluster}, ` +
+    `⚠ Check Feature Compliance on endpoint: ${endpointId}, cluster: ${featureData.cluster}, ` +
     `feature: ${featureName} (bit ${featureData.bit} in featureMap attribute)`
 
   let missingTerms = []

--- a/src-electron/importexport/import-json.js
+++ b/src-electron/importexport/import-json.js
@@ -2023,7 +2023,7 @@ async function setConformanceWarnings(
       }
     }
 
-    let contextMessage = `On endpoint ${endpointId}, cluster: ${cluster.name}, `
+    let contextMessage = `⚠ Check Feature Compliance on endpoint: ${endpointId}, cluster: ${cluster.name}, `
 
     /* If unsupported elements are enabled or required elements are disabled, 
       they are considered non-conforming. A corresponding warning message will be 

--- a/src/store/zap/actions.js
+++ b/src/store/zap/actions.js
@@ -942,30 +942,11 @@ export async function setDeviceTypeFeatures(
   axiosRequests
     .$serverGet(restApi.uri.deviceTypeFeatures, config)
     .then((resp) => {
-      let deviceTypeFeatures = []
-      /* For a device type feature under the same endpoint and cluster, but different device types,
-        merge their rows into one and combine their device type names into a list. */
-      resp.data.forEach((row) => {
-        const key = `${row.endpointTypeClusterId}-${row.featureId}`
-        if (key in deviceTypeFeatures) {
-          let existingRow = deviceTypeFeatures[key]
-          if (!existingRow.deviceTypes.includes(row.deviceType)) {
-            existingRow.deviceTypes.push(row.deviceType)
-          }
-        } else {
-          deviceTypeFeatures[key] = {
-            ...row,
-            deviceTypes: [row.deviceType]
-          }
-          delete deviceTypeFeatures[key].deviceType
-        }
-      })
-      deviceTypeFeatures = Object.values(deviceTypeFeatures)
-
+      let deviceTypeFeatures = resp.data
       context.commit('setDeviceTypeFeatures', deviceTypeFeatures)
 
-      let enabledDeviceTypeFeatures = []
       // turn on the toggle for features with their bit set in featureMap attribute
+      let enabledDeviceTypeFeatures = []
       deviceTypeFeatures.forEach((feature) => {
         if (feature.featureMapValue & (1 << feature.bit)) {
           enabledDeviceTypeFeatures.push(

--- a/src/util/common-mixin.js
+++ b/src/util/common-mixin.js
@@ -436,7 +436,7 @@ export default {
       let clusterName = this.selectedCluster.label
       let endpointId = this.endpointId[this.selectedEndpointId]
       let contextMessage =
-        `On endpoint ${endpointId}, ` +
+        `⚠ Check Feature Compliance on endpoint: ${endpointId}, ` +
         `cluster: ${clusterName}, ${elementType.slice(0, -1)}: `
       let requiredText = this[`${elementType}RequiredByConform`][element.id]
       let notSupportedText =

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -297,31 +297,36 @@ test(
     let featureMap = { HS: 0, EHUE: 0, CL: 0, XY: 1, CT: 1, UNKNOWN: 0 }
     let deviceType = 'Matter Extended Color Light'
     let cluster = 'Color Control'
+    let featureBit = 0
     let featureHS = {
       cluster: cluster,
       name: 'Hue/Saturation',
       code: 'HS',
       conformance: 'O',
-      deviceTypes: [deviceType]
+      deviceTypes: [deviceType],
+      bit: featureBit
     }
     let featureXY = {
       cluster: cluster,
       name: 'XY',
       code: 'XY',
       conformance: 'M',
-      deviceTypes: [deviceType]
+      deviceTypes: [deviceType],
+      bit: featureBit
     }
     let featureUnknown = {
       cluster: cluster,
       name: 'Unknown',
       code: 'UNKNOWN',
       conformance: 'Feature1 | Feature2',
-      deviceTypes: [deviceType]
+      deviceTypes: [deviceType],
+      bit: featureBit
     }
     let endpointId = 1
     let result = {}
     let expectedWarning = ''
     let warningPrefix = `On endpoint ${endpointId}, cluster: ${cluster}, `
+    let featureBitMessage = `(bit ${featureBit} in featureMap attribute)`
 
     // 1. test enable an optional feature
     featureMap['HS'] = 1
@@ -359,7 +364,7 @@ test(
     // should throw and display warning
     expectedWarning =
       warningPrefix +
-      `feature: ${featureXY.name} should be enabled, ` +
+      `feature: ${featureXY.name} ${featureBitMessage} should be enabled, ` +
       `as it is mandatory for device type: ${deviceType}`
     expect(result.displayWarning).toBeTruthy()
     expect(result.disableChange).toBeFalsy()
@@ -385,7 +390,7 @@ test(
     )
     expectedWarning =
       warningPrefix +
-      `feature: ${featureUnknown.name} cannot be enabled ` +
+      `feature: ${featureUnknown.name} ${featureBitMessage} cannot be enabled ` +
       `as its conformance depends on non device type features ` +
       `Feature1, Feature2 with unknown values`
     // should display warning and disable the change
@@ -415,7 +420,7 @@ test(
     )
     expectedWarning =
       warningPrefix +
-      `feature: ${featureHS.name} ` +
+      `feature: ${featureHS.name} ${featureBitMessage} ` +
       `cannot be enabled as attribute ${descElement.name} ` +
       `depend on the feature and their conformance are too complex to parse.`
     expect(result.displayWarning).toBeTruthy()

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -325,7 +325,7 @@ test(
     let endpointId = 1
     let result = {}
     let expectedWarning = ''
-    let warningPrefix = `On endpoint ${endpointId}, cluster: ${cluster}, `
+    let warningPrefix = `⚠ Check Feature Compliance on endpoint: ${endpointId}, cluster: ${cluster}, `
     let featureBitMessage = `(bit ${featureBit} in featureMap attribute)`
 
     // 1. test enable an optional feature

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -296,19 +296,23 @@ test(
     }
     let featureMap = { HS: 0, EHUE: 0, CL: 0, XY: 1, CT: 1, UNKNOWN: 0 }
     let deviceType = 'Matter Extended Color Light'
+    let cluster = 'Color Control'
     let featureHS = {
+      cluster: cluster,
       name: 'Hue/Saturation',
       code: 'HS',
       conformance: 'O',
       deviceTypes: [deviceType]
     }
     let featureXY = {
+      cluster: cluster,
       name: 'XY',
       code: 'XY',
       conformance: 'M',
       deviceTypes: [deviceType]
     }
     let featureUnknown = {
+      cluster: cluster,
       name: 'Unknown',
       code: 'UNKNOWN',
       conformance: 'Feature1 | Feature2',
@@ -317,6 +321,7 @@ test(
     let endpointId = 1
     let result = {}
     let expectedWarning = ''
+    let warningPrefix = `On endpoint ${endpointId}, cluster: ${cluster}, `
 
     // 1. test enable an optional feature
     featureMap['HS'] = 1
@@ -353,9 +358,9 @@ test(
     )
     // should throw and display warning
     expectedWarning =
-      `On endpoint ${endpointId}, ` +
-      `feature ${featureXY.name} is disabled, ` +
-      `but it is mandatory for device type ${deviceType}`
+      warningPrefix +
+      `feature: ${featureXY.name} should be enabled, ` +
+      `as it is mandatory for device type: ${deviceType}`
     expect(result.displayWarning).toBeTruthy()
     expect(result.disableChange).toBeFalsy()
     expect(result.warningMessage).toBe(expectedWarning)
@@ -379,8 +384,8 @@ test(
       endpointId
     )
     expectedWarning =
-      `On Endpoint ${endpointId}, ` +
-      `feature ${featureUnknown.name} cannot be enabled ` +
+      warningPrefix +
+      `feature: ${featureUnknown.name} cannot be enabled ` +
       `as its conformance depends on non device type features ` +
       `Feature1, Feature2 with unknown values`
     // should display warning and disable the change
@@ -409,7 +414,8 @@ test(
       endpointId
     )
     expectedWarning =
-      `On endpoint ${endpointId}, feature ${featureHS.name} ` +
+      warningPrefix +
+      `feature: ${featureHS.name} ` +
       `cannot be enabled as attribute ${descElement.name} ` +
       `depend on the feature and their conformance are too complex to parse.`
     expect(result.displayWarning).toBeTruthy()

--- a/test/importexport.test.js
+++ b/test/importexport.test.js
@@ -513,6 +513,14 @@ test(
         'On endpoint 1, cluster: On/Off, attribute: GlobalSceneControl has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
       )
     ).toBeTruthy()
+
+    // disabled mandatory device type feature OnOff should trigger a notification
+    expect(
+      notificationMessages.includes(
+        'On endpoint 1, cluster: Level Control, feature: OnOff should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+      )
+    ).toBeTruthy()
+    console.log(notificationMessages)
   },
   testUtil.timeout.medium()
 )

--- a/test/importexport.test.js
+++ b/test/importexport.test.js
@@ -500,24 +500,24 @@ test(
     // Their element conformance warnings should be added to the notification table.
     expect(
       notificationMessages.includes(
-        'On endpoint 1, cluster: On/Off, command: OffWithEffect has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: On/Off, command: OffWithEffect has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
       )
     ).toBeTruthy()
     expect(
       notificationMessages.includes(
-        'On endpoint 1, cluster: On/Off, attribute: OnTime has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: On/Off, attribute: OnTime has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
       )
     ).toBeTruthy()
     expect(
       notificationMessages.includes(
-        'On endpoint 1, cluster: On/Off, attribute: GlobalSceneControl has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: On/Off, attribute: GlobalSceneControl has mandatory conformance to LT and should be enabled when feature: LT is enabled.'
       )
     ).toBeTruthy()
 
     // disabled mandatory device type feature OnOff should trigger a notification
     expect(
       notificationMessages.includes(
-        'On endpoint 1, cluster: Level Control, feature: OnOff (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: Level Control, feature: OnOff (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
   },

--- a/test/importexport.test.js
+++ b/test/importexport.test.js
@@ -517,10 +517,9 @@ test(
     // disabled mandatory device type feature OnOff should trigger a notification
     expect(
       notificationMessages.includes(
-        'On endpoint 1, cluster: Level Control, feature: OnOff should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        'On endpoint 1, cluster: Level Control, feature: OnOff (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
-    console.log(notificationMessages)
   },
   testUtil.timeout.medium()
 )

--- a/test/multi-protocol.test.js
+++ b/test/multi-protocol.test.js
@@ -181,28 +181,22 @@ test(
       (sn) => sn.message
     )
 
-    // Tests for the feature Map attribute compliance based on device type cluster features
+    // Tests for device type feature conformance
     expect(
       sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-onofflight, cluster: On/Off server needs bit 0 enabled in the Feature Map attribute'
+        'On endpoint 1, cluster: Level Control, feature: Lighting should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     expect(
       sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-dimmablelight, cluster: Level Control server needs bit 0 enabled in the Feature Map attribute'
+        'On endpoint 1, cluster: Level Control, feature: OnOff should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     expect(
       sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-dimmablelight, cluster: Level Control server needs bit 1 enabled in the Feature Map attribute'
-      )
-    ).toBeTruthy()
-
-    expect(
-      sessionNotificationMessages.includes(
-        '⚠ Check Device Type Compliance on endpoint: 1, device type: MA-dimmablelight, cluster: On/Off server needs bit 0 enabled in the Feature Map attribute'
+        'On endpoint 1, cluster: On/Off, feature: Lighting should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
@@ -233,10 +227,10 @@ test(
     }
 
     // one notification regarding multiple top level zcl propertoes
-    // 4 notifications regarding feature map attribute not set correctly
+    // 3 notifications regarding device type feature conformance
     // one notification regarding the enabled provisional cluster
     // 7 notifications regarding non-conformed elements
-    expect(sessionNotifications.length).toEqual(13)
+    expect(sessionNotifications.length).toEqual(12)
 
     // Test Accumulators in templates
     let zigbeeEndpointEvents = genResultZigbee.content['zap-event.h']

--- a/test/multi-protocol.test.js
+++ b/test/multi-protocol.test.js
@@ -184,19 +184,20 @@ test(
     // Tests for device type feature conformance
     expect(
       sessionNotificationMessages.includes(
-        'On endpoint 1, cluster: Level Control, feature: Lighting should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        'On endpoint 1, cluster: Level Control, feature: Lighting (bit 1 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     expect(
       sessionNotificationMessages.includes(
-        'On endpoint 1, cluster: Level Control, feature: OnOff should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        'On endpoint 1, cluster: Level Control, feature: OnOff (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
+    // warnings for same feature across different device types should be merged
     expect(
       sessionNotificationMessages.includes(
-        'On endpoint 1, cluster: On/Off, feature: Lighting should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        'On endpoint 1, cluster: On/Off, feature: Lighting (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter On/Off Light, Matter Dimmable Light'
       )
     ).toBeTruthy()
 
@@ -226,7 +227,7 @@ test(
       ).toBeTruthy()
     }
 
-    // one notification regarding multiple top level zcl propertoes
+    // one notification regarding multiple top level zcl properties
     // 3 notifications regarding device type feature conformance
     // one notification regarding the enabled provisional cluster
     // 7 notifications regarding non-conformed elements

--- a/test/multi-protocol.test.js
+++ b/test/multi-protocol.test.js
@@ -184,20 +184,20 @@ test(
     // Tests for device type feature conformance
     expect(
       sessionNotificationMessages.includes(
-        'On endpoint 1, cluster: Level Control, feature: Lighting (bit 1 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: Level Control, feature: Lighting (bit 1 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     expect(
       sessionNotificationMessages.includes(
-        'On endpoint 1, cluster: Level Control, feature: OnOff (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: Level Control, feature: OnOff (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter Dimmable Light'
       )
     ).toBeTruthy()
 
     // warnings for same feature across different device types should be merged
     expect(
       sessionNotificationMessages.includes(
-        'On endpoint 1, cluster: On/Off, feature: Lighting (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter On/Off Light, Matter Dimmable Light'
+        '⚠ Check Feature Compliance on endpoint: 1, cluster: On/Off, feature: Lighting (bit 0 in featureMap attribute) should be enabled, as it is mandatory for device type: Matter On/Off Light, Matter Dimmable Light'
       )
     ).toBeTruthy()
 
@@ -222,7 +222,7 @@ test(
     for (const element of nonConformElements) {
       expect(
         sessionNotificationMessages.includes(
-          `On endpoint 1, cluster: On/Off, ${element.type}: ${element.name} has mandatory conformance to LT and should be disabled when feature: LT is disabled.`
+          `⚠ Check Feature Compliance on endpoint: 1, cluster: On/Off, ${element.type}: ${element.name} has mandatory conformance to LT and should be disabled when feature: LT is disabled.`
         )
       ).toBeTruthy()
     }

--- a/test/resource/non-conform-elements.zap
+++ b/test/resource/non-conform-elements.zap
@@ -2623,19 +2623,19 @@
           "enabled": 1,
           "commands": [
             {
-              "name": "AddGroupResponse",
-              "code": 0,
-              "mfgCode": null,
-              "source": "server",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
               "name": "AddGroup",
               "code": 0,
               "mfgCode": null,
               "source": "client",
               "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "AddGroupResponse",
+              "code": 0,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
               "isEnabled": 1
             },
             {
@@ -2715,7 +2715,7 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "",
-              "reportable": 1,
+              "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
@@ -2825,6 +2825,7 @@
           "define": "SCENES_CLUSTER",
           "side": "server",
           "enabled": 1,
+          "apiMaturity": "provisional",
           "commands": [
             {
               "name": "AddScene",
@@ -2843,19 +2844,19 @@
               "isEnabled": 1
             },
             {
-              "name": "ViewSceneResponse",
-              "code": 1,
-              "mfgCode": null,
-              "source": "server",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
               "name": "ViewScene",
               "code": 1,
               "mfgCode": null,
               "source": "client",
               "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "ViewSceneResponse",
+              "code": 1,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
               "isEnabled": 1
             },
             {
@@ -3171,7 +3172,7 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0",
-              "reportable": 1,
+              "reportable": 0,
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
@@ -3197,7 +3198,7 @@
               "code": 16387,
               "mfgCode": null,
               "side": "server",
-              "type": "StartUpOnOffEnum",
+              "type": "OnOffStartUpOnOff",
               "included": 1,
               "storageOption": "RAM",
               "singleton": 0,
@@ -3534,7 +3535,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "3",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/zcl-builtin/matter/data-model/chip/matter-devices.xml
+++ b/zcl-builtin/matter/data-model/chip/matter-devices.xml
@@ -224,6 +224,11 @@ limitations under the License.
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                  <feature code="LT" name="Lighting">
+                    <mandatoryConform/>
+                  </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -237,6 +242,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                  <feature code="OO" name="OnOff">
+                    <mandatoryConform/>
+                  </feature>
+                  <feature code="LT" name="Lighting">
+                    <mandatoryConform/>
+                  </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>


### PR DESCRIPTION
- Set warnings for non-conforming device type features when importing a ZAP file, replacing outdated warnings on feature map attributes as they do not cover all non-conforming cases
- Improve feature conform warning message and code for warning generation
- Update unit tests to align with the new warnings and add a .zap file for testing non-conformance.
- Parent task: JIRA ZAPP-1565.